### PR TITLE
fix(api): refetch player values on pick changes, drop redundant /value call in PlayerInfoModal

### DIFF
--- a/fe/src/features/players/components/PlayerInfoModal.tsx
+++ b/fe/src/features/players/components/PlayerInfoModal.tsx
@@ -18,6 +18,7 @@ type PlayerDetailResponse = {
   throws: string;
   team: string;
   positions: string[];
+  valueScore: number;
   headshotUrl?: string | null;
   stats: {
     g: number;
@@ -26,12 +27,6 @@ type PlayerDetailResponse = {
     ops: number;
     ip: number;
   };
-};
-
-type PlayerValueResponse = {
-  playerId: number;
-  name: string;
-  valueScore: number;
 };
 
 const HITTER_POSITIONS = new Set([
@@ -80,7 +75,6 @@ export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [detail, setDetail] = useState<PlayerDetailResponse | null>(null);
-  const [valueScore, setValueScore] = useState<number | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -91,6 +85,7 @@ export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [open, onClose]);
 
+  // 상세 API 단일 호출 — 응답에 valueScore 가 이미 포함되어 있으므로 별도 /value 호출은 불필요.
   useEffect(() => {
     if (!open || playerId === null) return;
 
@@ -100,38 +95,14 @@ export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
       setError(null);
     });
 
-    Promise.allSettled([
-      apiGet<PlayerDetailResponse>(`/api/players/${playerId}`, undefined, controller.signal),
-      apiGet<PlayerValueResponse>(`/api/players/${playerId}/value`, undefined, controller.signal),
-    ])
-      .then((results) => {
+    apiGet<PlayerDetailResponse>(`/api/players/${playerId}`, undefined, controller.signal)
+      .then((data) => {
         if (controller.signal.aborted) return;
-
-        const detailResult = results[0];
-        const valueResult = results[1];
-
-        if (detailResult.status === "fulfilled") {
-          setDetail(detailResult.value);
-        } else {
-          setDetail(null);
-          setError(
-            detailResult.reason instanceof Error
-              ? detailResult.reason.message
-              : "Failed to load player detail"
-          );
-          return;
-        }
-
-        if (valueResult.status === "fulfilled") {
-          setValueScore(valueResult.value.valueScore);
-        } else {
-          setValueScore(null);
-        }
+        setDetail(data);
       })
       .catch((err: unknown) => {
         if (err instanceof DOMException && err.name === "AbortError") return;
         setDetail(null);
-        setValueScore(null);
         setError(err instanceof Error ? err.message : "Failed to load player information");
       })
       .finally(() => {
@@ -201,7 +172,7 @@ export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
               <div className="rounded-2xl border border-white/20 bg-black/20 px-5 py-3 text-center">
                 <div className="text-[11px] font-black uppercase tracking-wide text-white/60">PPA-DUN Value</div>
                 <div className="mt-1 text-3xl font-black text-emerald-300">
-                  {formatPpa(valueScore)}
+                  {formatPpa(detail.valueScore)}
                 </div>
               </div>
             </div>

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -400,6 +400,7 @@ export default function DraftPage() {
 
   // 인증된 사용자에게만 PPA 값 + 추천 bid 를 불러와 playerId 로 공개 목록과 머지한다.
   // 로그아웃 시 값을 즉시 지워서 UI 에 남지 않도록 함.
+  // picks 가 바뀔 때마다 (Add/Taken/Remove) 재호출 — 잔여 예산 변동에 따라 백엔드의 추천 bid 가 갱신되기 때문.
   useEffect(() => {
     if (!authed) {
       queueMicrotask(() => setPlayerValues(null));
@@ -424,7 +425,7 @@ export default function DraftPage() {
       });
 
     return () => controller.abort();
-  }, [authed]);
+  }, [authed, picks]);
 
   // Toggle player selection for A/B comparison (max 2 players).
   const handleCompareToggle = (playerId: string) => {


### PR DESCRIPTION


## What
<!-- What did you do? -->
- DraftPage: added picks to the values-fetch effect dependency so /api/draft/players/values refetches after every Add/Taken/Remove.
- PlayerInfoModal: removed the redundant /api/players/{id}/value call. The detail endpoint already returns valueScore, so a single GET now powers the modal.
- Dropped the now-unused PlayerValueResponse type and valueScore state.
- 
## Why
<!-- Why did you do it? -->
Recommended bids depend on remaining budget, which changes with every pick. Without refetching, the displayed bids go stale immediately after a pick — backend recomputes but the frontend was holding the initial values. Aligning fetch lifetime to picks state keeps recommendations accurate.

The duplicate /value call was historical from when the detail endpoint didn't include valueScore. It does now, so dropping the second call removes a network round trip on every modal open.

## Related Issue
<!-- e.g. #123 -->
#69 